### PR TITLE
Updated camerax

### DIFF
--- a/config.gradle
+++ b/config.gradle
@@ -16,9 +16,9 @@ ext {
             version_appcompat             : "1.1.0",
             localbroadcastmanager         : "1.0.0",
 
-            camerax_view                  : "1.0.0-alpha10",
-            camerax_version               : "1.0.0-beta03",
-            camera_core_version           : "1.0.0-beta03",
+            camerax_view                  : "1.0.0-alpha14",
+            camerax_version               : "1.0.0-beta07",
+            camera_core_version           : "1.0.0-beta07",
             futures_version               : "1.0.0",
 
             // ucrop

--- a/picture_library/src/main/java/com/luck/picture/lib/PictureCustomCameraActivity.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/PictureCustomCameraActivity.java
@@ -12,6 +12,7 @@ import android.view.WindowManager;
 import android.widget.Button;
 import android.widget.TextView;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.luck.picture.lib.camera.CustomCameraView;
 import com.luck.picture.lib.camera.listener.CameraListener;
 import com.luck.picture.lib.camera.view.CaptureLayout;
@@ -27,6 +28,7 @@ import java.lang.ref.WeakReference;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.camera.core.CameraX;
+import androidx.camera.lifecycle.ProcessCameraProvider;
 import androidx.camera.view.CameraView;
 
 /**
@@ -203,16 +205,6 @@ public class PictureCustomCameraActivity extends PictureSelectorCameraEmptyActiv
             PictureSelectionConfig.listener.onCancel();
         }
         closeActivity();
-    }
-
-    @SuppressLint("RestrictedApi")
-    @Override
-    protected void onDestroy() {
-        if (mCameraView != null) {
-            CameraX.unbindAll();
-            mCameraView = null;
-        }
-        super.onDestroy();
     }
 
     @Override

--- a/picture_library/src/main/java/com/luck/picture/lib/camera/CustomCameraView.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/camera/CustomCameraView.java
@@ -39,6 +39,7 @@ import java.lang.ref.WeakReference;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.camera.core.ImageCapture;
+import androidx.camera.core.ImageCapture.OutputFileOptions;
 import androidx.camera.core.ImageCaptureException;
 import androidx.camera.core.VideoCapture;
 import androidx.camera.view.CameraView;
@@ -136,7 +137,8 @@ public class CustomCameraView extends RelativeLayout {
                     return;
                 }
                 mPhotoFile = imageOutFile;
-                mCameraView.takePicture(imageOutFile, ContextCompat.getMainExecutor(getContext()),
+                ImageCapture.OutputFileOptions options = new ImageCapture.OutputFileOptions.Builder(imageOutFile).build();
+                mCameraView.takePicture(options, ContextCompat.getMainExecutor(getContext()),
                         new MyImageResultCallback(getContext(), mConfig, imageOutFile,
                                 mImagePreview, mCaptureLayout, mImageCallbackListener, mCameraListener));
             }

--- a/picture_library/src/main/java/com/luck/picture/lib/instagram/InstagramCameraView.java
+++ b/picture_library/src/main/java/com/luck/picture/lib/instagram/InstagramCameraView.java
@@ -103,7 +103,8 @@ public class InstagramCameraView extends FrameLayout {
                 }
                 mCameraView.setCaptureMode(androidx.camera.view.CameraView.CaptureMode.IMAGE);
                 File imageOutFile = createImageFile();
-                mCameraView.takePicture(imageOutFile, ContextCompat.getMainExecutor(getContext().getApplicationContext()), new OnImageSavedCallbackImpl(InstagramCameraView.this, imageOutFile));
+                ImageCapture.OutputFileOptions options = new ImageCapture.OutputFileOptions.Builder(imageOutFile).build();
+                mCameraView.takePicture(options, ContextCompat.getMainExecutor(getContext().getApplicationContext()), new OnImageSavedCallbackImpl(InstagramCameraView.this, imageOutFile));
             }
 
             @Override


### PR DESCRIPTION
fixed https://github.com/JessYanCoding/InsGallery/issues/15
fixed without access in black layout in cameraview

There is no need to explicitly call CameraX.unbindAll() , since the UseCase is bound to a lifecycle and resources will be automatically freed when the lifecycle reaches the destroyed state. Also, Activity has no onDestroyView method, which is instead owned by Fragments. By the way, for Fragments the proper lifecycle to bind the UseCases to would be the viewLifecycleOwner ‘s lifecycle.